### PR TITLE
feat(cli-handler) Add a cli handler that will simplify the CLI specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vs
 
 scripts
+tests/**/target_dir/**/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +31,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
@@ -65,17 +80,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.57"
+name = "filetime"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -89,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -109,10 +136,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "num-traits"
-version = "0.2.16"
+name = "memchr"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -125,9 +158,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -142,17 +175,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "rs-file-sorter"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "filetime",
+ "regex",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -167,9 +240,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -177,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
@@ -192,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -202,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -215,15 +288,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
-name = "windows"
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,7 @@ test = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+chrono = "0.4.31"
+filetime = "0.2.22"
+regex = "1.10.2"
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# rs-file-sorter
+
+## Description
+
+rs-file-sorter is a small project that aim to help us, according to a predefined sorting strategy, sort our files faster.

--- a/src/cli_handler/cli_handler.rs
+++ b/src/cli_handler/cli_handler.rs
@@ -1,0 +1,194 @@
+use crate::utils::logger::Logger;
+
+use super::{
+    compound_structs::{ArgBuilder, ParamBuilder},
+    parser::{parse_cli, ParsedCommand},
+};
+
+#[derive(Debug, Clone)]
+pub struct CliHandlerCommand {
+    pub logger: Logger,
+    pub command_name: String,
+    pub command_description: String,
+    pub args: Vec<ArgBuilder>,
+    pub params: Vec<ParamBuilder>,
+    pub handler: fn(&ParsedCommand) -> (),
+}
+
+impl CliHandlerCommand {
+    pub fn help(&self) {
+        let command_name = &self.command_name;
+        println!("COMMANDS");
+        print!("\t");
+        println!(
+            "{command_name}: {} (enter 'help {command_name}' for more information)",
+            self.command_description,
+        );
+        println!("");
+        println!("PARAMETERS");
+        for param in &self.params {
+            print!("\t");
+            println!("{}: {}", param.name, param.description);
+        }
+        println!("");
+        println!("ARGUMENTS");
+        for arg in &self.args {
+            print!("\t");
+            println!(
+                "--{}: {}. Accepted values: {:#?}",
+                arg.name, arg.description, arg.expected_value_type
+            );
+        }
+        println!("");
+    }
+}
+
+pub struct CliHandler {
+    pub command_handlers: Vec<CliHandlerCommand>,
+    pub logger: Logger,
+}
+
+impl CliHandler {
+    pub fn handle(&self, input: String) {
+        let arg_prefix = String::from("--");
+        let command = CliHandler::extract_command_from_input(input);
+        let command_name = match command.first() {
+            Some(value) => value,
+            None => {
+                self.logger.error("Please provide a valid command.");
+                return;
+            }
+        };
+
+        // If command is help, we want to provide the associated help message.
+        if command_name.to_string() == String::from("help") {
+            self.handle_help(&command);
+            return;
+        }
+
+        let command_handler = match self.command_handler_from(command_name) {
+            Some(value) => value,
+            None => {
+                self.logger
+                    .error("Command invalid. Please type help to get the list of valid commands.");
+                return;
+            }
+        };
+        let expected_args = CliHandler::expected_arg_from(&command_handler);
+        let parsed_command = parse_cli(command, expected_args, arg_prefix);
+        if !self.validate(command_handler.clone(), parsed_command.clone()) {
+            return;
+        }
+
+        let command_handler_fn = command_handler.handler;
+        command_handler_fn(&parsed_command.clone())
+    }
+
+    fn handle_help(&self, command: &Vec<String>) {
+        match command.get(1) {
+            None => self.help(),
+            Some(specific_command_name) => {
+                match self.command_handler_from(specific_command_name) {
+                    Some(specific_command_handler) => specific_command_handler.help(),
+                    None => {
+                        self.logger.error(
+                            "Command invalid. Please type help to get the list of valid commands.",
+                        );
+                    }
+                };
+            }
+        }
+    }
+
+    fn command_handler_from(&self, command_name: &String) -> Option<CliHandlerCommand> {
+        self.command_handlers
+            .clone()
+            .into_iter()
+            .find(|handler| handler.command_name == command_name.to_string())
+    }
+
+    fn expected_arg_from(command_handler: &CliHandlerCommand) -> Vec<String> {
+        let expected_args = command_handler
+            .args
+            .clone()
+            .into_iter()
+            .map(|arg| arg.name.to_string())
+            .collect();
+        expected_args
+    }
+
+    fn extract_command_from_input(input: String) -> Vec<String> {
+        let command: Vec<String> = input
+            .split(' ')
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+        command
+    }
+
+    fn help(&self) {
+        println!("COMMANDS");
+        for command_handler in &self.command_handlers {
+            print!("\t");
+            println!(
+                "{}: {} (enter 'help {}' for more information)",
+                command_handler.command_name,
+                command_handler.command_description,
+                command_handler.command_name
+            );
+        }
+        println!("");
+    }
+
+    fn validate(
+        &self,
+        command_specification: CliHandlerCommand,
+        parsed_command: ParsedCommand,
+    ) -> bool {
+        for arg in command_specification.args.clone().into_iter() {
+            match arg.validate(parsed_command.clone()) {
+                super::compound_structs::ArgValidationErrorEnum::NoError => todo!(),
+                super::compound_structs::ArgValidationErrorEnum::UnknownArgument => {
+                    let all_argument = command_specification
+                        .args
+                        .clone()
+                        .into_iter()
+                        .map(|arg| arg.name)
+                        .collect::<Vec<String>>()
+                        .join(", ");
+                    self.logger.error(&format!(
+                        "Unknown argument: expected {} but received {}.",
+                        all_argument, arg.name
+                    ));
+                    return false;
+                }
+                super::compound_structs::ArgValidationErrorEnum::UnexpectedValue(received_value) => {
+                    let possible_values = arg.clone().expected_value_type;
+                    self.logger.error(&format!(
+                        "Unexpected argument value: expected {:#?} but received {:#?}.",
+                        possible_values, received_value
+                    ));
+                    return false;
+                }
+            }
+        }
+
+        if command_specification.params.len() < parsed_command.params.len() {
+            self.logger.error(&format!(
+                "Too much parameters: expected {} but recevied {}.",
+                command_specification.params.len(),
+                parsed_command.params.len()
+            ));
+            return false;
+        } else if command_specification.params.len() > parsed_command.params.len() {
+            self.logger.error(&format!(
+                "Not enough parameters: expected {} but recevied {}.",
+                command_specification.params.len(),
+                parsed_command.params.len()
+            ));
+            return false;
+        }
+
+        true
+    }
+}

--- a/src/cli_handler/cli_handler_builder.rs
+++ b/src/cli_handler/cli_handler_builder.rs
@@ -1,0 +1,188 @@
+use crate::utils::logger::Logger;
+
+use super::{
+    cli_handler::{CliHandler, CliHandlerCommand},
+    compound_structs::{ArgBuilder, CommandBuilder, ParamBuilder},
+    parser::ParsedCommand,
+};
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum ArgValueTypes {
+    NoValue,
+    Multiple,
+    Single,
+}
+
+pub struct CliHandlerBuilder {
+    current_command: Option<CommandBuilder>,
+    current_args: Option<Vec<ArgBuilder>>,
+    current_params: Option<Vec<ParamBuilder>>,
+    current_handler: Option<fn(&ParsedCommand) -> ()>,
+    commands: Vec<CliHandlerCommand>,
+    logger: Logger,
+}
+
+impl CliHandlerBuilder {
+    pub fn new(logger: Logger) -> Self {
+        CliHandlerBuilder {
+            current_command: None,
+            current_args: None,
+            current_params: None,
+            current_handler: None,
+            commands: vec![],
+            logger,
+        }
+    }
+
+    pub fn command(mut self, name: String, description: String, logger: Logger) -> Self {
+        // Error case isn't problematic in command method.
+        // It only means that we're initiating the first command specification.
+        let _ = self.push_current_command();
+
+        self.current_args = None;
+        self.current_params = None;
+        self.current_command = Some(CommandBuilder {
+            name,
+            description,
+            logger: logger.clone(),
+        });
+
+        self
+    }
+
+    pub fn args(
+        mut self,
+        name: String,
+        description: String,
+        expected_value_type: Vec<ArgValueTypes>,
+    ) -> Self {
+        let arg_builder = ArgBuilder {
+            name: name.clone(),
+            description,
+            expected_value_type: expected_value_type.clone(),
+        };
+
+        if expected_value_type.is_empty() {
+            self.logger
+                .error("args method cannot receive empty 'expected_value_type' vector.");
+        }
+
+        if self.current_command.is_none() {
+            self.logger.error(&format!(
+                "cannot specify argument '{name}' outside of command context."
+            ));
+        }
+
+        match &self.current_args {
+            Some(arg) => {
+                let arg_already_specified = arg.iter().any(|a| a.name == name);
+                if arg_already_specified {
+                    let command_name = self
+                        .current_command
+                        .clone()
+                        .expect("Should be able to acces command when calling args")
+                        .name
+                        .clone();
+                    self.logger.error(&format!(
+                        "argument '{name}' have already been declared for command '{}'.",
+                        command_name
+                    ))
+                }
+                let mut arg_vec = arg.clone();
+
+                arg_vec.push(arg_builder);
+                self.current_args = Some(arg_vec);
+            }
+            None => {
+                self.current_args = Some(vec![arg_builder]);
+            }
+        };
+
+        self
+    }
+
+    pub fn params(mut self, name: String, description: String) -> Self {
+        let param_builder = ParamBuilder {
+            name: name.clone(),
+            description,
+        };
+
+        if self.current_command.is_none() {
+            self.logger.error(&format!(
+                "cannot specify parameter '{name}' outside of command context."
+            ));
+        }
+
+        match &self.current_params {
+            Some(param) => {
+                let param_already_specified = param.iter().any(|a| a.name == name);
+                if param_already_specified {
+                    let command_name = self
+                        .current_command
+                        .clone()
+                        .expect("Should be able to acces command when calling args")
+                        .name
+                        .clone();
+                    self.logger.error(&format!(
+                        "parameter '{name}' have already been declared for command '{}'.",
+                        command_name
+                    ))
+                }
+                let mut param_vec = param.clone();
+                param_vec.push(param_builder);
+                self.current_params = Some(param_vec);
+            }
+            None => {
+                self.current_params = Some(vec![param_builder]);
+            }
+        };
+
+        self
+    }
+
+    pub fn handler(mut self, handler: fn(&ParsedCommand) -> ()) -> Self {
+        match self.current_handler {
+            Some(_) => self
+                .logger
+                .error("handler should only be set once per command."),
+            None => self.current_handler = Some(handler),
+        };
+
+        self
+    }
+
+    pub fn build(mut self) -> CliHandler {
+        match self.push_current_command() {
+            Err(_) => self.logger.error("no command has been specified."),
+            Ok(_) => (),
+        };
+
+        CliHandler {
+            command_handlers: self.commands.clone(),
+            logger: self.logger.clone(),
+        }
+    }
+
+    fn push_current_command(&mut self) -> Result<(), ()> {
+        match &self.current_command {
+            None => Err(()),
+            Some(current_command) => {
+                if self.current_handler.is_none() {
+                    self.logger
+                        .error("command specificatino needs to have a handler closure associated!");
+                }
+
+                self.commands.push(CliHandlerCommand {
+                    command_name: current_command.name.to_string(),
+                    command_description: current_command.description.to_string(),
+                    args: self.current_args.take().unwrap_or(vec![]).to_vec(),
+                    params: self.current_params.take().unwrap_or(vec![]).to_vec(),
+                    logger: current_command.logger.clone(),
+                    handler: self.current_handler.unwrap(),
+                });
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/cli_handler/compound_structs.rs
+++ b/src/cli_handler/compound_structs.rs
@@ -1,0 +1,57 @@
+use crate::utils::logger::Logger;
+
+use super::{
+    cli_handler_builder::ArgValueTypes,
+    parser::{ArgValue, ParsedCommand},
+};
+
+pub enum ArgValidationErrorEnum {
+    NoError,
+    UnknownArgument,
+    UnexpectedValue(ArgValue),
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandBuilder {
+    pub name: String,
+    pub description: String,
+    pub logger: Logger,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArgBuilder {
+    pub name: String,
+    pub description: String,
+    pub expected_value_type: Vec<ArgValueTypes>,
+}
+
+impl ArgBuilder {
+    pub fn validate(&self, parsed_command: ParsedCommand) -> ArgValidationErrorEnum {
+        let parsed_arg = match parsed_command
+            .args
+            .into_iter()
+            .find(|arg| arg.arg_name == self.name.to_string())
+        {
+            Some(parsed_arg) => parsed_arg,
+            None => {
+                return ArgValidationErrorEnum::UnknownArgument;
+            }
+        };
+
+        let parsed_arg_type_accepted = self
+            .expected_value_type
+            .iter()
+            .any(|expected_value| parsed_arg.arg_value.is_same_type(expected_value.clone()));
+        if !parsed_arg_type_accepted {
+            return ArgValidationErrorEnum::UnexpectedValue(parsed_arg.arg_value);
+        }
+
+        ArgValidationErrorEnum::NoError
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParamBuilder {
+    pub name: String,
+    pub description: String,
+}

--- a/src/cli_handler/mod.rs
+++ b/src/cli_handler/mod.rs
@@ -1,0 +1,7 @@
+pub mod parser;
+pub mod cli_handler_builder;
+mod cli_handler;
+mod compound_structs;
+
+#[cfg(test)]
+mod tests;

--- a/src/cli_handler/parser.rs
+++ b/src/cli_handler/parser.rs
@@ -1,0 +1,125 @@
+use super::cli_handler_builder::ArgValueTypes;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ArgValue {
+    NotProvided,
+    NoValue,
+    Multiple(Vec<String>),
+    Single(String),
+}
+
+impl ArgValue {
+    pub fn is_same_type (&self, compare_to: ArgValueTypes) -> bool {
+        match self {
+            ArgValue::NotProvided => true,
+            ArgValue::NoValue => compare_to == ArgValueTypes::NoValue,
+            ArgValue::Multiple(_) => compare_to == ArgValueTypes::Multiple,
+            ArgValue::Single(_) => compare_to == ArgValueTypes::Single,
+        }
+    }
+}
+
+impl std::fmt::Display for ArgValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArgValue::NotProvided => write!(f, "not provided"),
+            ArgValue::NoValue => write!(f, "alone"),
+            ArgValue::Multiple(_) => write!(f, "multiples values"),
+            ArgValue::Single(_) => write!(f, "only one value"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedArgs {
+    pub arg_name: String,
+    pub arg_value: ArgValue,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedCommand {
+    pub command_name: String,
+    pub args: Vec<ParsedArgs>,
+    pub params: Vec<String>,
+}
+
+fn init_args(expected_args: Vec<String>) -> Vec<ParsedArgs> {
+    let mut args: Vec<ParsedArgs> = vec![];
+    for arg_name in expected_args {
+        args.push(ParsedArgs {
+            arg_name: String::from(arg_name),
+            arg_value: ArgValue::NotProvided,
+        });
+    }
+    args
+}
+
+pub fn parse_cli(
+    command: Vec<String>,
+    expected_args: Vec<String>,
+    arg_prefix: String,
+) -> ParsedCommand {
+    let command_name = command
+        .first()
+        .expect("[Cli Parser] Expect to receive non-empty command input.");
+
+    let mut args = init_args(expected_args.clone());
+    let mut params: Vec<String> = vec![];
+    let mut current_arg_name = String::from("");
+
+    for i in 1..command.len() {
+        let v = &command[i];
+        if v.starts_with(&arg_prefix) {
+            let arg_name = v
+                .strip_prefix(&arg_prefix)
+                .expect("[Cli Parser] An error occured.");
+
+            if current_arg_name != "" {
+                args.iter_mut()
+                    .find(|a| a.arg_name == current_arg_name)
+                    .expect("Argument not found")
+                    .arg_value = ArgValue::NoValue;
+            }
+
+            current_arg_name = String::from(arg_name);
+            continue;
+        }
+
+        if current_arg_name == "" {
+            params.push(String::from(v));
+        } else {
+            let current_arg = args
+                .iter_mut()
+                .find(|a| a.arg_name == current_arg_name)
+                .expect("Argument not found");
+
+            current_arg.arg_value = match &current_arg.arg_value {
+                ArgValue::NotProvided => ArgValue::Single(String::from(v)),
+                ArgValue::Multiple(a) => {
+                    let mut vec_clone = a.clone();
+                    vec_clone.push(String::from(v));
+                    ArgValue::Multiple(vec_clone)
+                }
+                ArgValue::Single(a) => ArgValue::Multiple(vec![a.clone(), String::from(v)]),
+                ArgValue::NoValue => panic!(
+                    "[Cli Parser] Arguments has already been encoutered as providing no value."
+                ),
+            };
+
+            current_arg_name = String::from("");
+        }
+    }
+
+    if current_arg_name != "" {
+        args.iter_mut()
+            .find(|a| a.arg_name == current_arg_name)
+            .expect("Argument not found")
+            .arg_value = ArgValue::NoValue;
+    }
+
+    ParsedCommand {
+        command_name: String::from(command_name).clone(),
+        args,
+        params,
+    }
+}

--- a/src/cli_handler/tests.rs
+++ b/src/cli_handler/tests.rs
@@ -1,0 +1,581 @@
+mod parser_tests {
+    use crate::cli_handler::parser::{parse_cli, ArgValue};
+
+    #[test]
+    #[should_panic(expected = "[Cli Parser] Expect to receive non-empty command input.")]
+    fn test_parser_no_command_panic() {
+        parse_cli(vec![], vec![], String::from(""));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parser_unexpected_arg_panic() {
+        parse_cli(
+            vec![String::from("my-cmd"), String::from("unexpected-arg")],
+            vec![String::from("expected-arg")],
+            String::from(""),
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parser_repeating_argvalue_no_value_panic() {
+        parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-1"),
+                String::from("--arg-1"),
+            ],
+            vec![String::from("arg-1")],
+            String::from(""),
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parser_overwriting_argvalue_no_value_panic() {
+        parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-1"),
+                String::from("--arg-1"),
+                String::from("arg-value-1"),
+            ],
+            vec![String::from("arg-1")],
+            String::from(""),
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parser_overwriting_value_with_no_value() {
+        parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-1"),
+                String::from("arg-value-1"),
+                String::from("--arg-1"),
+                String::from("--arg-2"),
+            ],
+            vec![String::from("arg-1"), String::from("arg-2")],
+            String::from(""),
+        );
+    }
+
+    #[test]
+    fn test_parser_correctly_parse_command_name() {
+        let parsed_command = parse_cli(vec![String::from("my-cmd")], vec![], String::from("--"));
+        assert_eq!(parsed_command.command_name, String::from("my-cmd"));
+    }
+
+    #[test]
+    fn test_parser_correctly_parse_params() {
+        let parsed_command = parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("param-1"),
+                String::from("param-2"),
+            ],
+            vec![],
+            String::from("--"),
+        );
+        assert_eq!(parsed_command.params.len(), 2);
+        assert_eq!(parsed_command.params[0], String::from("param-1"));
+        assert_eq!(parsed_command.params[1], String::from("param-2"));
+    }
+
+    #[test]
+    fn test_parser_correctly_parse_args_with_single_value() {
+        let parsed_command = parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-1"),
+                String::from("value-1"),
+            ],
+            vec![String::from("arg-1")],
+            String::from("--"),
+        );
+        assert_eq!(parsed_command.params.len(), 0);
+        assert_eq!(parsed_command.args.len(), 1);
+        assert_eq!(parsed_command.args[0].arg_name, "arg-1");
+        assert_eq!(
+            parsed_command.args[0].arg_value,
+            ArgValue::Single(String::from("value-1"))
+        );
+    }
+
+    #[test]
+    fn test_parser_correctly_parse_two_args_with_single_value() {
+        let parsed_command = parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-1"),
+                String::from("value-1"),
+                String::from("--arg-2"),
+                String::from("value-2"),
+            ],
+            vec![String::from("arg-1"), String::from("arg-2")],
+            String::from("--"),
+        );
+        assert_eq!(parsed_command.params.len(), 0);
+        assert_eq!(parsed_command.args.len(), 2);
+        assert_eq!(parsed_command.args[0].arg_name, "arg-1");
+        assert_eq!(
+            parsed_command.args[0].arg_value,
+            ArgValue::Single(String::from("value-1"))
+        );
+        assert_eq!(parsed_command.args[1].arg_name, "arg-2");
+        assert_eq!(
+            parsed_command.args[1].arg_value,
+            ArgValue::Single(String::from("value-2"))
+        );
+    }
+
+    #[test]
+    fn test_parser_correctly_parse_args_with_multiple_values() {
+        let parsed_command = parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-1"),
+                String::from("value-1"),
+                String::from("--arg-1"),
+                String::from("value-2"),
+                String::from("--arg-1"),
+                String::from("value-3"),
+            ],
+            vec![String::from("arg-1")],
+            String::from("--"),
+        );
+        assert_eq!(parsed_command.params.len(), 0);
+        assert_eq!(parsed_command.args.len(), 1);
+        assert_eq!(parsed_command.args[0].arg_name, "arg-1");
+        assert_eq!(
+            parsed_command.args[0].arg_value,
+            ArgValue::Multiple(vec![
+                String::from("value-1"),
+                String::from("value-2"),
+                String::from("value-3")
+            ])
+        );
+    }
+
+    #[test]
+    fn test_parser_correctly_parse_combinaison_of_singe_arg_and_multiple_arg() {
+        let parsed_command = parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-1"),
+                String::from("value-1"),
+                String::from("--arg-1"),
+                String::from("value-2"),
+                String::from("--arg-2"),
+                String::from("value-3"),
+            ],
+            vec![String::from("arg-1"), String::from("arg-2")],
+            String::from("--"),
+        );
+        assert_eq!(parsed_command.params.len(), 0);
+        assert_eq!(parsed_command.args.len(), 2);
+        assert_eq!(parsed_command.args[0].arg_name, "arg-1");
+        assert_eq!(
+            parsed_command.args[0].arg_value,
+            ArgValue::Multiple(vec![String::from("value-1"), String::from("value-2")])
+        );
+        assert_eq!(parsed_command.args[1].arg_name, "arg-2");
+        assert_eq!(
+            parsed_command.args[1].arg_value,
+            ArgValue::Single(String::from("value-3"))
+        );
+    }
+
+    #[test]
+    fn test_parser_correctly_parse_combinaison_of_singe_arg_multiple_arg_and_no_value_arg() {
+        let parsed_command = parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-2"),
+                String::from("--arg-3"),
+                String::from("value-1"),
+                String::from("--arg-3"),
+                String::from("value-2"),
+                String::from("--arg-4"),
+                String::from("value-3"),
+            ],
+            vec![
+                String::from("arg-1"),
+                String::from("arg-2"),
+                String::from("arg-3"),
+                String::from("arg-4"),
+            ],
+            String::from("--"),
+        );
+        assert_eq!(parsed_command.params.len(), 0);
+        assert_eq!(parsed_command.args.len(), 4);
+        assert_eq!(parsed_command.args[0].arg_name, "arg-1");
+        assert_eq!(parsed_command.args[0].arg_value, ArgValue::NotProvided);
+        assert_eq!(parsed_command.args[1].arg_name, "arg-2");
+        assert_eq!(parsed_command.args[1].arg_value, ArgValue::NoValue);
+        assert_eq!(parsed_command.args[2].arg_name, "arg-3");
+        assert_eq!(
+            parsed_command.args[2].arg_value,
+            ArgValue::Multiple(vec![String::from("value-1"), String::from("value-2")])
+        );
+        assert_eq!(parsed_command.args[3].arg_name, "arg-4");
+        assert_eq!(
+            parsed_command.args[3].arg_value,
+            ArgValue::Single(String::from("value-3"))
+        );
+    }
+
+    #[test]
+    fn test_parser_two_following_args_should_create_two_no_value_args() {
+        let parsed_command = parse_cli(
+            vec![
+                String::from("my-cmd"),
+                String::from("--arg-1"),
+                String::from("--arg-2"),
+            ],
+            vec![String::from("arg-1"), String::from("arg-2")],
+            String::from("--"),
+        );
+
+        assert_eq!(parsed_command.params.len(), 0);
+
+        assert_eq!(parsed_command.args.len(), 2);
+        assert_eq!(parsed_command.args[0].arg_name, String::from("arg-1"));
+        assert_eq!(parsed_command.args[0].arg_value, ArgValue::NoValue);
+        assert_eq!(parsed_command.args[1].arg_name, String::from("arg-2"));
+        assert_eq!(parsed_command.args[1].arg_value, ArgValue::NoValue);
+    }
+}
+
+mod cli_handler_tests {}
+
+mod cli_handler_builder_tests {
+    use crate::{
+        cli_handler::{
+            cli_handler_builder::{ArgValueTypes, CliHandlerBuilder},
+            parser::ArgValue,
+        },
+        utils::logger::Logger,
+    };
+
+    #[test]
+    #[should_panic = "[ERROR] [TEST_COMMAND] command specificatino needs to have a handler closure associated!"]
+    fn test_missing_handler_in_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .build();
+
+        // Should have fail before.
+        assert!(false);
+    }
+
+    #[test]
+    #[should_panic = "[ERROR] [TEST_COMMAND] handler should only be set once per command."]
+    fn test_two_handler_in_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .handler(|_| ())
+            .handler(|_| ())
+            .build();
+
+        // Should have fail before.
+        assert!(false);
+    }
+
+    #[test]
+    #[should_panic = "[ERROR] [TEST_COMMAND] no command has been specified."]
+    fn test_no_command_specified_when_building() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        CliHandlerBuilder::new(logger).build();
+
+        // Should have fail before.
+        assert!(false);
+    }
+
+    #[test]
+    fn test_can_create_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        let cli_handler = CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .handler(|_| ())
+            .build();
+
+        assert_eq!(cli_handler.command_handlers.len(), 1);
+        assert_eq!(
+            cli_handler.command_handlers[0].command_name,
+            String::from("my-command")
+        );
+        assert_eq!(
+            cli_handler.command_handlers[0].command_description,
+            String::from("my description")
+        );
+        assert_eq!(cli_handler.command_handlers[0].args.len(), 0);
+        assert_eq!(cli_handler.command_handlers[0].params.len(), 0);
+    }
+
+    #[test]
+    fn test_can_add_one_arg_to_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        let cli_handler = CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .args(
+                String::from("arg-1"),
+                String::from("description of arg-1"),
+                vec![ArgValueTypes::NoValue],
+            )
+            .handler(|_| ())
+            .build();
+
+        assert_eq!(cli_handler.command_handlers.len(), 1);
+
+        let args = cli_handler.command_handlers[0].args.clone();
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, String::from("arg-1"));
+        assert_eq!(args[0].description, String::from("description of arg-1"));
+        assert_eq!(args[0].expected_value_type.len(), 1);
+        assert_eq!(args[0].expected_value_type[0], ArgValueTypes::NoValue);
+    }
+
+    #[test]
+    fn test_specified_arg_can_hold_multiple_expected_values() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        let cli_handler = CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .args(
+                String::from("arg-1"),
+                String::from("description of arg-1"),
+                vec![ArgValueTypes::NoValue, ArgValueTypes::Single],
+            )
+            .handler(|_| ())
+            .build();
+
+        assert_eq!(cli_handler.command_handlers.len(), 1);
+
+        let args = cli_handler.command_handlers[0].args.clone();
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, String::from("arg-1"));
+        assert_eq!(args[0].description, String::from("description of arg-1"));
+        assert_eq!(args[0].expected_value_type.len(), 2);
+        assert_eq!(args[0].expected_value_type[0], ArgValueTypes::NoValue);
+        assert_eq!(args[0].expected_value_type[1], ArgValueTypes::Single);
+    }
+
+    #[test]
+    fn test_can_add_multiple_arg_to_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        let cli_handler = CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .args(
+                String::from("arg-1"),
+                String::from("description of arg-1"),
+                vec![ArgValueTypes::NoValue],
+            )
+            .args(
+                String::from("arg-2"),
+                String::from("description of arg-2"),
+                vec![ArgValueTypes::Single, ArgValueTypes::Multiple],
+            )
+            .handler(|_| ())
+            .build();
+
+        assert_eq!(cli_handler.command_handlers.len(), 1);
+
+        let args = cli_handler.command_handlers[0].args.clone();
+        assert_eq!(args.len(), 2);
+
+        // test for arg-1
+        assert_eq!(args[0].name, String::from("arg-1"));
+        assert_eq!(args[0].description, String::from("description of arg-1"));
+        assert_eq!(args[0].expected_value_type.len(), 1);
+        assert_eq!(args[0].expected_value_type[0], ArgValueTypes::NoValue);
+
+        // test for arg-2
+        assert_eq!(args[1].name, String::from("arg-2"));
+        assert_eq!(args[1].description, String::from("description of arg-2"));
+        assert_eq!(args[1].expected_value_type.len(), 2);
+        assert_eq!(args[1].expected_value_type[0], ArgValueTypes::Single);
+        assert_eq!(args[1].expected_value_type[1], ArgValueTypes::Multiple);
+    }
+
+    #[test]
+    #[should_panic = "[ERROR] [TEST_COMMAND] argument 'arg-1' have already been declared for command 'my-command'."]
+    fn test_error_when_arg_specification_is_duplicated_for_same_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .args(
+                String::from("arg-1"),
+                String::from("This is a description of arg-1"),
+                vec![ArgValueTypes::NoValue],
+            )
+            .args(
+                String::from("arg-1"),
+                String::from("This is a description of arg-1"),
+                vec![ArgValueTypes::NoValue],
+            )
+            .handler(|_| ())
+            .build();
+
+        assert!(false);
+    }
+
+    #[test]
+    #[should_panic = "[ERROR] [TEST_COMMAND] args method cannot receive empty 'expected_value_type' vector."]
+    fn test_error_when_arg_specification_receive_empty_expected_value_list() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .args(
+                String::from("arg-1"),
+                String::from("This is a description of arg-1"),
+                vec![],
+            )
+            .handler(|_| ())
+            .build();
+
+        assert!(false);
+    }
+
+    #[test]
+    #[should_panic = "[ERROR] [TEST_COMMAND] cannot specify argument 'arg-1' outside of command context."]
+    fn test_error_when_arg_is_declare_outside_of_command_context() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        CliHandlerBuilder::new(logger)
+            .args(
+                String::from("arg-1"),
+                String::from("This is a description of arg-1"),
+                vec![ArgValueTypes::NoValue],
+            )
+            .build();
+
+        assert!(false);
+    }
+
+    #[test]
+    fn test_can_add_one_param_to_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        let cli_handler = CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .params(
+                String::from("param-1"),
+                String::from("description of param-1"),
+            )
+            .handler(|_| ())
+            .build();
+
+        assert_eq!(cli_handler.command_handlers.len(), 1);
+
+        let params = cli_handler.command_handlers[0].params.clone();
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].name, String::from("param-1"));
+        assert_eq!(params[0].description, String::from("description of param-1"));
+    }
+
+    #[test]
+    fn test_can_add_multiple_param_to_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        let cli_handler = CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .params(
+                String::from("param-1"),
+                String::from("description of param-1"),
+            )
+            .params(
+                String::from("param-2"),
+                String::from("description of param-2"),
+            )
+            .handler(|_| ())
+            .build();
+
+        assert_eq!(cli_handler.command_handlers.len(), 1);
+
+        let params = cli_handler.command_handlers[0].params.clone();
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].name, String::from("param-1"));
+        assert_eq!(params[0].description, String::from("description of param-1"));
+        assert_eq!(params[1].name, String::from("param-2"));
+        assert_eq!(params[1].description, String::from("description of param-2"));
+    }
+
+    #[test]
+    #[should_panic = "[ERROR] [TEST_COMMAND] parameter 'param-1' have already been declared for command 'my-command'."]
+    fn test_error_when_param_specification_is_duplicated_for_same_command() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        CliHandlerBuilder::new(logger)
+            .command(
+                String::from("my-command"),
+                String::from("my description"),
+                Logger::new("my-command", true),
+            )
+            .params(
+                String::from("param-1"),
+                String::from("This is a description of param-1"),
+            )
+            .params(
+                String::from("param-1"),
+                String::from("This is a description of param-1"),
+            )
+            .handler(|_| ())
+            .build();
+
+        assert!(false);
+    }
+
+    #[test]
+    #[should_panic = "[ERROR] [TEST_COMMAND] cannot specify parameter 'param-1' outside of command context."]
+    fn test_error_when_param_is_declare_outside_of_command_context() {
+        let logger = Logger::new("TEST_COMMAND", true);
+        CliHandlerBuilder::new(logger)
+            .params(
+                String::from("param-1"),
+                String::from("This is a description of param-1"),
+            )
+            .build();
+
+        assert!(false);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod sortering_strategies;
-mod utils;
-pub mod sorter;
+pub mod cli_handler;
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,11 @@
+use rs_file_sorter::cli_handler::cli_handler_builder::CliHandlerBuilder;
+use rs_file_sorter::utils::logger::Logger;
+use std::env;
+
 fn main() {
-    println!("test");
+    let input = env::args().collect::<Vec<String>>().join(" ");
+    let logger = Logger::new("Command Handler", true);
+    let command_handler = CliHandlerBuilder::new(logger).build();
+
+    command_handler.handle(input);
 }

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -1,0 +1,41 @@
+
+#[derive(Debug)]
+pub struct Logger {
+    name: &'static str,
+    debug_mode: bool
+}
+
+impl Clone for Logger {
+    fn clone(&self) -> Self {
+        Self { name: self.name.clone(), debug_mode: self.debug_mode.clone() }
+    }
+}
+
+impl Logger {
+    pub fn new (name: &'static str, debug_mode: bool) -> Logger {
+        Logger {
+            name,
+            debug_mode
+        }
+    }
+
+    pub fn warn (&self, message: &str) -> () {
+        println!("[WARN] [{}] {}", self.name, message);
+    }
+
+    pub fn error (&self, message: &str) -> () {
+        panic!("[ERROR] [{}] {}", self.name, message);
+    }
+
+    pub fn log (&self, message: &str) -> () {
+        println!("[LOG] [{}] {}", self.name, message);
+    }
+
+    pub fn debug (&self, message: &str) -> () {
+        if !self.debug_mode {
+            return;
+        }
+
+        println!("[DEBUG] [{}] {}", self.name, message);
+    }
+}


### PR DESCRIPTION
The goal of the PR is to create a simple design for CLI creation. Using `CliHandlerBuilder`, we will be able to easily specify the basic pieces needed in order to create cli commands.